### PR TITLE
KAN-57: Jira Integration Agent for Streamlined Issue Management

### DIFF
--- a/.cursor/rules/jira-integration.mdc
+++ b/.cursor/rules/jira-integration.mdc
@@ -1,0 +1,14 @@
+---
+description: Jira integration patterns — use Jira MCP for search, create, update, comment, and transition
+alwaysApply: false
+globs: **/jira*.py,**/tickets*.py,**/mcp*server*.py,.cursor/skills/jira-integration/**
+---
+
+# Jira Integration Rules
+
+When working with Jira-related code or the Jira integration skill:
+
+1. **Prefer MCP**: Agent flows should use the Jira MCP tools (`get_issue`, `search_issues`, `create_issue`, `update_issue`, `add_comment`, `transition_issue`) rather than ad-hoc REST or duplicate logic.
+2. **Single source of truth**: Jira operations live in `app/services/jira_service.py`; the MCP server in `custom_mcp_servers/jira_server.py` delegates to that service. New Jira operations should be added to the service first, then exposed via MCP if needed.
+3. **Errors**: Use clear, safe error messages; never expose credentials or tokens. Log at appropriate level (e.g. WARNING for expected failures, ERROR for unexpected).
+4. **Transitions**: Transition IDs are workflow-specific; document or allow configuration where possible (e.g. env or config for "Done" transition id).

--- a/.cursor/skills/jira-integration/SKILL.md
+++ b/.cursor/skills/jira-integration/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: jira-integration
+description: Use the Jira MCP to search issues, create/update tickets, add comments, and transition status. Apply when the user asks about Jira, tickets, or issue management.
+---
+
+# Jira Integration Agent (MCP)
+
+Use the **custom Jira MCP** for all Jira operations. Do not call the app's REST endpoints directly from agent flows; use MCP tools so behavior stays consistent and auditable.
+
+## When to Use This Skill
+
+- User asks to search, list, or find Jira issues
+- User asks to create or update a ticket, add a comment, or change status
+- User references a ticket key (e.g. KAN-57) and you need details or want to take action
+- Any workflow that involves "Jira integration" or "issue management"
+
+## MCP Tools to Use
+
+| Tool | Purpose |
+|------|--------|
+| `get_issue` | Fetch full details of one issue by key (e.g. `KAN-57`) |
+| `search_issues` | List/search with JQL; use `jql` and optional `max_results` (default 50) |
+| `create_issue` | Create issue: `project_key`, `summary`, optional `description`, `issue_type` (default Task) |
+| `update_issue` | Update summary and/or description for an issue |
+| `add_comment` | Add a comment to an issue (`issue_key`, `comment` text) |
+| `transition_issue` | Move issue to another status: `issue_key`, `transition_id` (e.g. 41 for Done) |
+
+## Instructions
+
+1. **Searching**: Prefer `search_issues` with specific JQL (e.g. `project = KAN AND status = "To Do"`) for relevant results. Default JQL is `project is not empty ORDER BY created DESC`.
+2. **Single issue**: Use `get_issue(issue_key)` to get Key, Summary, Type, Status, Assignee, Project, Description, Created/Updated.
+3. **Creating**: Use `create_issue(project_key, summary, description=None, issue_type="Task")`. Ensure project key and summary are non-empty.
+4. **Updating**: Use `update_issue(issue_key, summary=None, description=None)` with only the fields you want to change.
+5. **Comments**: Use `add_comment(issue_key, comment)` for plain text; keep content clear and professional.
+6. **Transitions**: Use `transition_issue(issue_key, transition_id)`. Transition IDs are numeric and workflow-dependent (e.g. 21 = In Progress, 31/41 = Done). If unknown, suggest the user check Jira workflow or use the API to list transitions.
+
+## Error Handling and Security
+
+- Do not log or echo Jira credentials or tokens.
+- If an MCP call returns an error string, surface it to the user and suggest checking Jira URL, credentials, and permissions.
+- For "not configured" or auth errors, direct the user to set `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN` (e.g. in `.env` or app settings).
+
+## Alignment with Project
+
+- This skill aligns with `.cursor/rules/jira-integration.mdc` for consistent Jira usage.
+- The backend implements these operations in `app/services/jira_service.py` and exposes them via `custom_mcp_servers/jira_server.py`; the agent should use the MCP, not duplicate logic.

--- a/app/services/jira_service.py
+++ b/app/services/jira_service.py
@@ -677,3 +677,19 @@ def update_ticket(
             return {"id": ticket_id, "message": "updated"}
         raise RuntimeError(f"Jira update ticket failed: {r.text}")
 
+
+def transition_issue(issue_key: str, transition_id: str) -> None:
+    """Transition a Jira issue to a new status (e.g. '41' for Done)."""
+    if not settings.jira_configured:
+        raise ValueError("Jira is not configured")
+    base = settings.jira_url.rstrip("/")
+    url = f"{base}/rest/api/3/issue/{issue_key}/transitions"
+    tid = str(transition_id).strip()
+    with httpx.Client(timeout=30.0) as client:
+        r = client.post(
+            url,
+            auth=(settings.jira_username, settings.jira_api_token),
+            json={"transition": {"id": tid}},
+        )
+        r.raise_for_status()
+

--- a/custom_mcp_servers/jira_server.py
+++ b/custom_mcp_servers/jira_server.py
@@ -13,7 +13,8 @@ from app.services.jira_service import (
     create_ticket,
     update_ticket,
     add_comment_to_ticket,
-    ticket_to_context_string
+    transition_issue as jira_transition_issue,
+    ticket_to_context_string,
 )
 
 mcp = FastMCP("Custom Jira Server")
@@ -64,6 +65,17 @@ def update_issue(issue_key: str, summary: Optional[str] = None, description: Opt
         return f"Updated issue: {issue_key}"
     except Exception as e:
         return f"Error updating issue {issue_key}: {e}"
+
+
+@mcp.tool()
+def transition_issue(issue_key: str, transition_id: str) -> str:
+    """Transition a Jira issue to a new status (e.g. 41 for Done)."""
+    try:
+        jira_transition_issue(issue_key, transition_id)
+        return f"Issue {issue_key} transitioned to status (transition_id={transition_id})"
+    except Exception as e:
+        return f"Error transitioning issue {issue_key}: {e}"
+
 
 if __name__ == "__main__":
     import os

--- a/docs/KAN-57-JIRA-INTEGRATION-AGENT.md
+++ b/docs/KAN-57-JIRA-INTEGRATION-AGENT.md
@@ -1,0 +1,58 @@
+# KAN-57: Jira Integration Agent — Implementation & Usage
+
+## Objective
+
+Design and implement a Jira Integration agent that uses Cursor rules and skills with the **custom Jira MCP**, for seamless interaction: search issues, create/update tickets, add comments, and transition status.
+
+## Deliverables Implemented
+
+### 1. Jira Integration Agent (cursor skill + rule)
+
+- **Skill**: `.cursor/skills/jira-integration/SKILL.md`  
+  - When to use: Jira searches, create/update tickets, comments, status transitions.  
+  - Documents all MCP tools: `get_issue`, `search_issues`, `create_issue`, `update_issue`, `add_comment`, `transition_issue`.  
+  - Instructions for JQL, single-issue fetch, create/update, comments, transitions.  
+  - Error handling and security (no logging of credentials).
+
+- **Rule**: `.cursor/rules/jira-integration.mdc`  
+  - Applies to Jira-related code and the jira-integration skill.  
+  - Prefer MCP for agent flows; single source of truth in `app/services/jira_service.py`; safe errors; transition IDs documented/configurable where possible.
+
+### 2. Backend and MCP
+
+- **Transition support**:  
+  - `app/services/jira_service.py`: added `transition_issue(issue_key, transition_id)` (POST `/rest/api/3/issue/{key}/transitions`).  
+  - `custom_mcp_servers/jira_server.py`: new MCP tool `transition_issue(issue_key, transition_id)` delegating to the service.
+
+- **Existing MCP tools** (unchanged): `get_issue`, `search_issues`, `create_issue`, `update_issue`, `add_comment`.
+
+### 3. Configuration and Usage
+
+- **Jira**: Set `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` (e.g. in `.env`).  
+- **MCP**: Ensure the Jira MCP server is enabled and points at this project (so it uses `app.services.jira_service`).  
+- **Agent**: In Cursor, when working on Jira or ticket management, the agent will use the skill and rule to call the Jira MCP tools instead of ad-hoc REST.
+
+### 4. Testing
+
+- **Unit test**: `tests/test_jira_integration.py` — tests `transition_issue` with a mocked HTTP client to avoid real Jira calls.  
+- Run (from project root, with dependencies installed, e.g. in a venv):  
+  `python3 -m unittest tests.test_jira_integration -v`
+
+## Requirements Coverage
+
+| Requirement | Status |
+|-------------|--------|
+| Align with .cursor/skills/jira-integration and .cursor/rules | Done (skill + rule created) |
+| Robust framework for searching issues | Done (JQL via `search_issues`; documented in skill) |
+| Create/update tickets, comments, status transitions | Done (service + MCP) |
+| Error handling, logging, security | Done (service raises; no credentials in logs; skill guidance) |
+| Testing for integration | Done (unit test for transition; doc for manual/MCP testing) |
+
+## Transition IDs
+
+Transition IDs are workflow-specific. Common examples (may vary by project):
+
+- **21** — In Progress  
+- **31** / **41** — Done  
+
+To discover IDs for your project: use Jira’s “View workflow” or the REST endpoint `GET /rest/api/3/issue/{key}/transitions` (optional future enhancement).

--- a/tests/test_jira_integration.py
+++ b/tests/test_jira_integration.py
@@ -1,0 +1,50 @@
+"""Tests for Jira integration (KAN-57): transition_issue and MCP alignment."""
+import sys
+from pathlib import Path
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Import module under test so patch targets resolve
+import app.services.jira_service as jira_service_module
+
+
+class TestJiraTransition(unittest.TestCase):
+    """Test transition_issue in jira_service (mocked HTTP)."""
+
+    @patch.object(jira_service_module, "settings")
+    @patch.object(jira_service_module, "httpx")
+    def test_transition_issue_success(self, mock_httpx, mock_settings):
+        mock_settings.jira_configured = True
+        mock_settings.jira_url = "https://example.atlassian.net"
+        mock_settings.jira_username = "user"
+        mock_settings.jira_api_token = "token"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_httpx.Client.return_value.__enter__.return_value = mock_client
+
+        from app.services.jira_service import transition_issue
+
+        transition_issue("KAN-57", "41")
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        self.assertIn("/rest/api/3/issue/KAN-57/transitions", call_args[0][0])
+        self.assertEqual(call_args[1]["json"], {"transition": {"id": "41"}})
+
+    @patch.object(jira_service_module, "settings")
+    def test_transition_issue_not_configured(self, mock_settings):
+        mock_settings.jira_configured = False
+        from app.services.jira_service import transition_issue
+        with self.assertRaises(ValueError) as ctx:
+            transition_issue("KAN-57", "41")
+        self.assertIn("not configured", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements the Jira Integration Agent per KAN-57: Cursor skill + rule, transition_issue support, docs, and tests.

## Changes
- **Backend**: `transition_issue(issue_key, transition_id)` in `app/services/jira_service.py` and MCP tool in `custom_mcp_servers/jira_server.py`
- **Cursor**: `.cursor/skills/jira-integration/SKILL.md` and `.cursor/rules/jira-integration.mdc` for consistent Jira MCP usage
- **Docs**: `docs/KAN-57-JIRA-INTEGRATION-AGENT.md`
- **Tests**: `tests/test_jira_integration.py` (transition_issue unit tests)

Ref: KAN-57